### PR TITLE
Utils (putSignOn): Use white text on Spruce too

### DIFF
--- a/src/main/java/me/crafter/mc/lockettepro/Utils.java
+++ b/src/main/java/me/crafter/mc/lockettepro/Utils.java
@@ -56,7 +56,9 @@ public class Utils {
         }
         updateSign(newsign);
         Sign sign = (Sign)newsign.getState();
-        if (newsign.getType() == Material.DARK_OAK_WALL_SIGN) {
+        blockType = newsign.getType();
+        // TODO (1.16): Add CRIMSON and WARPED
+        if (blockType == Material.DARK_OAK_WALL_SIGN || blockType == Material.SPRUCE_WALL_SIGN) {
             sign.setColor(DyeColor.WHITE);
         }
         sign.setLine(0, line1);


### PR DESCRIPTION
Spruce is also a dark-colored wood that would benefit from using white text. WCAG contrast calculations show that white text is more legible on a #664F2F background. (Same goes for the two 1.16 woods not yet here.)