### PR TITLE
Properly Lockable Lecterns

### DIFF
--- a/src/main/java/me/crafter/mc/lockettepro/BlockPlayerListener.java
+++ b/src/main/java/me/crafter/mc/lockettepro/BlockPlayerListener.java
@@ -17,6 +17,7 @@ import org.bukkit.event.block.SignChangeEvent;
 import org.bukkit.event.player.PlayerBucketEmptyEvent;
 import org.bukkit.event.player.PlayerBucketFillEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerTakeLecternBookEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -357,6 +358,15 @@ public class BlockPlayerListener implements Listener {
         Player player = event.getPlayer();
         Block block = event.getBlockClicked().getRelative(event.getBlockFace());
         if (LocketteProAPI.isProtected(block) && !(LocketteProAPI.isOwner(block, player) || LocketteProAPI.isOwnerOfSign(block, player))) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onLecternTake(PlayerTakeLecternBookEvent event){
+        Player player = event.getPlayer();
+        Block block = event.getLectern().getBlock();
+        if(LocketteProAPI.isProtected(block) && !(LocketteProAPI.isOwner(block, player) || LocketteProAPI.isOwnerOfSign(block, player))){
             event.setCancelled(true);
         }
     }

--- a/src/main/java/me/crafter/mc/lockettepro/Config.java
+++ b/src/main/java/me/crafter/mc/lockettepro/Config.java
@@ -176,11 +176,10 @@ public class Config {
         String[] timer_signs = {"[Timer:@]", "[timer:@]"};
         config.addDefault("timer-signs", timer_signs);
         String[] lockables = {"CHEST","TRAPPED_CHEST","FURNACE","BURNING_FURNACE","HOPPER","BREWING_STAND","DIAMOND_BLOCK",
-                "OAK_DOOR","SPRUCE_DOOR","BIRCH_DOOR","JUNGLE_DOOR","ACACIA_DOOR","DARK_OAK_DOOR","IRON_DOOR"};
+                "OAK_DOOR","SPRUCE_DOOR","BIRCH_DOOR","JUNGLE_DOOR","ACACIA_DOOR","DARK_OAK_DOOR","IRON_DOOR", "LECTERN"};
         config.addDefault("lockables", lockables);
         String[] protection_exempt = {"nothing"};
         config.addDefault("protection-exempt", protection_exempt);
-
         config.addDefault("lock-expire", false);
         config.addDefault("lock-expire-days", 999.9D);
         config.addDefault("lock-default-create-time-unix", -1L);

--- a/src/main/java/me/crafter/mc/lockettepro/LocketteProAPI.java
+++ b/src/main/java/me/crafter/mc/lockettepro/LocketteProAPI.java
@@ -141,6 +141,9 @@ public class LocketteProAPI {
                 if (isUserSingleBlock(relativechest, chestface.getOppositeFace(), player)) return true;
             }
             // Don't break here
+
+            case LECTERN:
+                return true; //Lecterns can be used, but not stolen from
         // Everything else (First block of container check goes here)
         default:
             if (isUserSingleBlock(block, null, player)) return true; 


### PR DESCRIPTION
Lock a Lectern with [Private]. A player can then read the contents of the book, but cannot take the book from the lectern.

Additionally, Lecterns were added to the default config generation as well