### PR TITLE
fully support 1.20.1 with bug fixes

### DIFF
--- a/src/main/java/me/crafter/mc/lockettepro/BlockPlayerListener.java
+++ b/src/main/java/me/crafter/mc/lockettepro/BlockPlayerListener.java
@@ -17,13 +17,11 @@ import org.bukkit.event.player.PlayerBucketFillEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerTakeLecternBookEvent;
 import org.bukkit.inventory.EquipmentSlot;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 public class BlockPlayerListener implements Listener {
 
@@ -230,8 +228,8 @@ public class BlockPlayerListener implements Listener {
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onAttemptChangeLockerSign(SignChangeEvent event){
         Block block = event.getBlock();
-        if(LocketteProAPI.isLockSign(block)||LocketteProAPI.isAdditionalSign(block)){
-            Sign sign = (Sign)block.getState();
+        if (LocketteProAPI.isLockSign(block) || LocketteProAPI.isAdditionalSign(block)) {
+            Sign sign = (Sign) block.getState();
             sign.setWaxed(true);
             sign.update();
             event.setCancelled(true);
@@ -242,8 +240,7 @@ public class BlockPlayerListener implements Listener {
     public void onAttemptBreakWaxedLockerSign(PlayerInteractEvent event){
         Action action = event.getAction();
         Block block = event.getClickedBlock();
-        boolean isAxe = Objects.equals(event.getItem(), new ItemStack(Material.WOODEN_AXE)) || Objects.equals(event.getItem(), new ItemStack(Material.STONE_AXE)) || Objects.equals(event.getItem(), new ItemStack(Material.IRON_AXE)) || Objects.equals(event.getItem(), new ItemStack(Material.GOLDEN_AXE)) || Objects.equals(event.getItem(), new ItemStack(Material.DIAMOND_AXE)) || Objects.equals(event.getItem(), new ItemStack(Material.NETHERITE_AXE));
-        if(action == Action.RIGHT_CLICK_BLOCK&&(LocketteProAPI.isLockSign(block)||LocketteProAPI.isAdditionalSign(block))&&isAxe){
+        if (action == Action.RIGHT_CLICK_BLOCK && (LocketteProAPI.isLockSign(block) || LocketteProAPI.isAdditionalSign(block)) && Utils.isAxe(event.getItem())) {
             event.setCancelled(true);
         }
     }

--- a/src/main/java/me/crafter/mc/lockettepro/BlockPlayerListener.java
+++ b/src/main/java/me/crafter/mc/lockettepro/BlockPlayerListener.java
@@ -3,6 +3,7 @@ package me.crafter.mc.lockettepro;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -16,11 +17,13 @@ import org.bukkit.event.player.PlayerBucketFillEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerTakeLecternBookEvent;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class BlockPlayerListener implements Listener {
 
@@ -227,10 +230,22 @@ public class BlockPlayerListener implements Listener {
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onAttemptChangeLockerSign(SignChangeEvent event){
         Block block = event.getBlock();
-        if(LocketteProAPI.isLockSign(block)){
+        if(LocketteProAPI.isLockSign(block)||LocketteProAPI.isAdditionalSign(block)){
+            Sign sign = (Sign)block.getState();
+            sign.setWaxed(true);
+            sign.update();
             event.setCancelled(true);
         }
         block.getWorld().spawnParticle(Particle.SMOKE_NORMAL,block.getLocation(),5);
+    }
+    @EventHandler(priority = EventPriority.HIGH,ignoreCancelled = true)
+    public void onAttemptBreakWaxedLockerSign(PlayerInteractEvent event){
+        Action action = event.getAction();
+        Block block = event.getClickedBlock();
+        boolean isAxe = Objects.equals(event.getItem(), new ItemStack(Material.WOODEN_AXE)) || Objects.equals(event.getItem(), new ItemStack(Material.STONE_AXE)) || Objects.equals(event.getItem(), new ItemStack(Material.IRON_AXE)) || Objects.equals(event.getItem(), new ItemStack(Material.GOLDEN_AXE)) || Objects.equals(event.getItem(), new ItemStack(Material.DIAMOND_AXE)) || Objects.equals(event.getItem(), new ItemStack(Material.NETHERITE_AXE));
+        if(action == Action.RIGHT_CLICK_BLOCK&&(LocketteProAPI.isLockSign(block)||LocketteProAPI.isAdditionalSign(block))&&isAxe){
+            event.setCancelled(true);
+        }
     }
 
     // Protect block from being destroyed

--- a/src/main/java/me/crafter/mc/lockettepro/Utils.java
+++ b/src/main/java/me/crafter/mc/lockettepro/Utils.java
@@ -288,6 +288,22 @@ public class Utils {
         }
     }
 
+    public static boolean isAxe(ItemStack itemStack) {
+        if (itemStack == null)
+            return false;
+        Material eventItemType = itemStack.getType();
+        return List.of(
+                Material.WOODEN_AXE,
+                Material.STONE_AXE,
+                Material.IRON_AXE,
+                Material.GOLDEN_AXE,
+                Material.DIAMOND_AXE,
+                Material.NETHERITE_AXE
+        ).contains(eventItemType);
+        // How about
+        // return eventItemType.name().endsWith("_AXE"); ?
+    }
+
     public static boolean isPlayerOnLine(Player player, String text) {
         if (Utils.isUsernameUuidLine(text)) {
             if (Config.isUuidEnabled()) {

--- a/src/main/java/me/crafter/mc/lockettepro/Utils.java
+++ b/src/main/java/me/crafter/mc/lockettepro/Utils.java
@@ -65,6 +65,7 @@ public class Utils {
         }
         sign.getSide(Side.FRONT).setLine(0, line1);
         sign.getSide(Side.FRONT).setLine(1, line2);
+        sign.setWaxed(true);
         sign.update();
         return newsign;
     }


### PR DESCRIPTION
1.Don't complain about my bad English
2.Add the Listener of the addition sign in the method "onAttemptChangeLockerSign"
3.when player right-click the old lock before version 1.20.1 , it will wax the sign for no more edit menu
4.When create a new sign lock, it will be waxed for no more edit menu
5.Player can't use axe to de-wax the locker sign