### PR TITLE
Waxed Signs on manual lock event

### DIFF
--- a/src/main/java/me/crafter/mc/lockettepro/BlockPlayerListener.java
+++ b/src/main/java/me/crafter/mc/lockettepro/BlockPlayerListener.java
@@ -139,6 +139,9 @@ public class BlockPlayerListener implements Listener {
                 if (!locked && !LocketteProAPI.isUpDownLockedDoor(block)) {
                     if (LocketteProAPI.isLockString(topline)) {
                         Utils.sendMessages(player, Config.getLang("locked-manual"));
+                        Sign sign = (Sign) event.getBlock().getState();
+                        sign.setWaxed(true);
+                        sign.update();
                         if (!player.hasPermission("lockettepro.lockothers")) { // Player with permission can lock with another name
                             event.setLine(1, player.getName());
                         }


### PR DESCRIPTION
Fixed issue where manually locked signs were still able to be forced into edit mode causing the sign to break, by waxing signs in the onManualLock event.