### PR TITLE
Fixing Priorities on Event calls to wax sign and cancel call if sign is edited

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     compileOnly "org.spigotmc:spigot-api:$minecraftVersion-R0.1-SNAPSHOT"
     compileOnly ("com.github.MilkBowl:VaultAPI:1.7"){ transitive = false}
     compileOnly ('com.sk89q.worldguard:worldguard-bukkit:7.1.0-SNAPSHOT') { transitive = false }
-    compileOnly (group: "com.comphenix.protocol", name: "ProtocolLib", version: "5.0.0"){ transitive = false}
+    compileOnly (group: "com.comphenix.protocol", name: "ProtocolLib", version: "5.1.0"){ transitive = false}
     compileOnly ('net.coreprotect:coreprotect:21.0'){ transitive = false}
 }
 

--- a/src/main/java/me/crafter/mc/lockettepro/BlockPlayerListener.java
+++ b/src/main/java/me/crafter/mc/lockettepro/BlockPlayerListener.java
@@ -103,7 +103,7 @@ public class BlockPlayerListener implements Listener {
     }
 
     // Manual protection
-    @EventHandler(priority = EventPriority.NORMAL)
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onManualLock(SignChangeEvent event) {
         if (!Tag.WALL_SIGNS.isTagged(event.getBlock().getType())) return;
         String topline = event.getLine(0);
@@ -228,7 +228,7 @@ public class BlockPlayerListener implements Listener {
     }
 
     //protect sign from being changed
-    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onAttemptChangeLockerSign(SignChangeEvent event){
         Block block = event.getBlock();
         if (LocketteProAPI.isLockSign(block) || LocketteProAPI.isAdditionalSign(block)) {


### PR DESCRIPTION
Fixed the onAttemptChangeLockerSign implementation to prevent signs from popping off chests when edited.

1) Made the onAttemptChangeLockerSign event occur first (Lower priority occurs first, see https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/EventPriority.html)

2) Made the onManualLock event cancellable from the onAttemptChangeLockerSign.